### PR TITLE
Add CodeMirror syntax highlighting with language selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Mergely 5.x CDN -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mergely/5.3.6/mergely.min.css" />
+
+  <!-- CodeMirror CDN -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css" />
+
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <h1>專業文字比對工具</h1>
+  <label for="language-select">語言：</label>
+  <select id="language-select">
+    <option value="javascript">JavaScript</option>
+    <option value="css">CSS</option>
+    <option value="htmlmixed">HTML</option>
+  </select>
   <div class="input-container">
     <textarea id="lhs">今天天氣很好，\n適合出門散步。\n</textarea>
     <textarea id="rhs">今天天氣很好，\n非常適合出門散步。\n</textarea>
@@ -18,6 +28,14 @@
 
   <!-- Mergely JS -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mergely/5.3.6/mergely.min.js"></script>
+
+  <!-- CodeMirror JS -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/javascript/javascript.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/css/css.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/xml/xml.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/htmlmixed/htmlmixed.min.js"></script>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,20 @@
 // 取得 DOM 元素
 const lhsTextarea = document.getElementById('lhs');
 const rhsTextarea = document.getElementById('rhs');
+const languageSelect = document.getElementById('language-select');
+
+// 使用 CodeMirror 取代 textarea
+const lhsEditor = CodeMirror.fromTextArea(lhsTextarea, {
+  lineNumbers: true,
+  lineWrapping: true,
+  mode: 'javascript',
+});
+
+const rhsEditor = CodeMirror.fromTextArea(rhsTextarea, {
+  lineNumbers: true,
+  lineWrapping: true,
+  mode: 'javascript',
+});
 
 // 初始化 Mergely，啟用行號與自動換行
 const mergely = new Mergely('#compare', {
@@ -10,13 +24,20 @@ const mergely = new Mergely('#compare', {
 
 // 更新比對結果的函式
 function updateDiff() {
-  mergely.lhs(lhsTextarea.value);
-  mergely.rhs(rhsTextarea.value);
+  mergely.lhs(lhsEditor.getValue());
+  mergely.rhs(rhsEditor.getValue());
 }
 
 // 首次載入完成後即執行比對
 mergely.once('updated', updateDiff);
 
 // 在輸入框輸入時即時比對
-lhsTextarea.addEventListener('input', updateDiff);
-rhsTextarea.addEventListener('input', updateDiff);
+lhsEditor.on('change', updateDiff);
+rhsEditor.on('change', updateDiff);
+
+// 切換語言時同步更換語法模式
+languageSelect.addEventListener('change', () => {
+  const mode = languageSelect.value;
+  lhsEditor.setOption('mode', mode);
+  rhsEditor.setOption('mode', mode);
+});

--- a/style.css
+++ b/style.css
@@ -19,6 +19,17 @@ textarea {
   box-sizing: border-box;
 }
 
+/* CodeMirror editor style */
+.CodeMirror {
+  flex: 1;
+  height: 150px;
+}
+
+/* language selector */
+#language-select {
+  margin-bottom: 10px;
+}
+
 /* ======== 按鈕樣式 ======== */
 button {
   padding: 8px 16px;


### PR DESCRIPTION
## Summary
- integrate CodeMirror library
- replace textareas with CodeMirror editors
- add dropdown to choose syntax mode and synchronize editors
- update styles for CodeMirror

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853e7cf3c64832fabcd745360c6351b