### PR TITLE
Add language selector and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,23 @@
 
   <!-- CodeMirror CDN -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/theme/dracula.min.css" />
 
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <h1>專業文字比對工具</h1>
+  <button id="theme-toggle">切換深色模式</button>
+  <label for="language-select">語言：</label>
+  <select id="language-select">
+    <option value="javascript">JavaScript</option>
+    <option value="css">CSS</option>
+    <option value="htmlmixed">HTML</option>
+  </select>
+  <div class="input-container">
+    <textarea id="lhs">今天天氣很好，\n適合出門散步。\n</textarea>
+    <textarea id="rhs">今天天氣很好，\n非常適合出門散步。\n</textarea>
+  </div>
   <div id="compare"></div>
 
   <!-- Mergely JS -->

--- a/script.js
+++ b/script.js
@@ -1,9 +1,58 @@
+// 取得 DOM 元素
+const lhsTextarea = document.getElementById('lhs');
+const rhsTextarea = document.getElementById('rhs');
+const languageSelect = document.getElementById('language-select');
+const themeToggle = document.getElementById('theme-toggle');
+
+// 使用 CodeMirror 取代 textarea
+const lhsEditor = CodeMirror.fromTextArea(lhsTextarea, {
+  lineNumbers: true,
+  lineWrapping: true,
+  mode: 'javascript',
+  theme: 'default',
+});
+
+const rhsEditor = CodeMirror.fromTextArea(rhsTextarea, {
+  lineNumbers: true,
+  lineWrapping: true,
+  mode: 'javascript',
+  theme: 'default',
+});
+
 // 初始化 Mergely，啟用行號與自動換行
 const mergely = new Mergely('#compare', {
   line_numbers: true,
   wrap_lines: true,
 });
 
-// 設定預設內容，可直接在編輯器內修改
-mergely.lhs('今天天氣很好，\n適合出門散步。\n');
-mergely.rhs('今天天氣很好，\n非常適合出門散步。\n');
+// 更新比對結果
+function updateDiff() {
+  mergely.lhs(lhsEditor.getValue());
+  mergely.rhs(rhsEditor.getValue());
+}
+
+// 首次載入完成後即執行比對
+mergely.once('updated', updateDiff);
+
+// 在輸入時即時比對
+lhsEditor.on('change', updateDiff);
+rhsEditor.on('change', updateDiff);
+
+// 切換語言並更新語法模式
+languageSelect.addEventListener('change', () => {
+  const mode = languageSelect.value;
+  lhsEditor.setOption('mode', mode);
+  rhsEditor.setOption('mode', mode);
+});
+
+// 切換深色模式
+let dark = false;
+function toggleTheme() {
+  dark = !dark;
+  document.body.classList.toggle('dark', dark);
+  const theme = dark ? 'dracula' : 'default';
+  lhsEditor.setOption('theme', theme);
+  rhsEditor.setOption('theme', theme);
+}
+
+themeToggle.addEventListener('click', toggleTheme);

--- a/style.css
+++ b/style.css
@@ -6,6 +6,11 @@ body {
   background-color: #fafafa;
 }
 
+body.dark {
+  background-color: #121212;
+  color: #eee;
+}
+
 /* ======== 輸入框區塊 ======== */
 .input-container {
   display: flex;
@@ -25,6 +30,11 @@ textarea {
   height: 150px;
 }
 
+body.dark .CodeMirror {
+  background-color: #2b2b2b;
+  color: #f8f8f2;
+}
+
 /* language selector */
 #language-select {
   margin-bottom: 10px;
@@ -40,4 +50,8 @@ button {
 #compare {
   height: 400px;
   border: 1px solid #ccc;
+}
+
+body.dark #compare {
+  border-color: #555;
 }


### PR DESCRIPTION
## Summary
- restore language selector and input fields
- add dark mode toggle with CodeMirror theme switching
- expose dark mode styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853ea0e4cec832f9f2f51fa0138c2ab