### PR TITLE
Fix solidity highlight by including clike mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,8 @@ button on the page.
 - Python
 - Solidity
 
+Note: Solidity syntax highlighting uses CodeMirror's `clike` mode as a
+dependency. Ensure the `clike` script is included before the Solidity mode.
+
 Additional CodeMirror modes can be added by including their corresponding
 scripts and options.

--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/javascript/javascript.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/css/css.min.js"></script>
+  <!-- Solidity mode depends on clike -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/clike/clike.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/xml/xml.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/htmlmixed/htmlmixed.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/python/python.min.js"></script>


### PR DESCRIPTION
## Summary
- add the clike mode required for CodeMirror's solidity mode
- document the dependency in README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6853f7499ff0832fb16bb46350fe2f1c